### PR TITLE
Add Github issue 3313 for Luigis Mansion

### DIFF
--- a/games/luigi-mansion-dark-moon/game.dat
+++ b/games/luigi-mansion-dark-moon/game.dat
@@ -1,6 +1,6 @@
 title = "Luigi's Mansion: Dark Moon"
 description = "Luigi's Mansion: Dark Moon, known in Japan as Luigi Mansion 2 (ルイージマンション2 Ruīji Manshon Tsū), and in Europe and Australia as Luigi's Mansion 2, is an action-adventure video game developed by Next Level Games and published by Nintendo for the Nintendo 3DS, and is the sequel to the 2001 game Luigi's Mansion for the GameCube."
-github_issues = [1779, 2514]
+github_issues = [1779, 2514, 3313]
 needs_system_files = false
 needs_shared_font = true
 


### PR DESCRIPTION
Just saw https://github.com/citra-emu/citra/issues/3313 was missing from the games wiki article. Someone should also add the "has-game-wiki-entry" tag for the issue in the citra repo after this PR is merged.